### PR TITLE
Revert "Revert "Update speech SDK 1.46""

### DIFF
--- a/metadata/latest/Microsoft.CognitiveServices.Speech.Remoteconversation.json
+++ b/metadata/latest/Microsoft.CognitiveServices.Speech.Remoteconversation.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.CognitiveServices.Speech.Remoteconversation",
-  "Version": "1.45.0",
+  "Version": "1.46.0",
   "Namespaces": "Microsoft.CognitiveServices.Speech.RemoteMeeting",
   "DocsCiConfigProperties": {},
   "MSDocService": "placeholder",

--- a/metadata/latest/Microsoft.CognitiveServices.Speech.json
+++ b/metadata/latest/Microsoft.CognitiveServices.Speech.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.CognitiveServices.Speech",
-  "Version": "1.45.0",
+  "Version": "1.46.0",
   "Namespaces": [
     "Azure.AI.Vision.Common.Internal",
     "Microsoft.CognitiveServices.Speech",


### PR DESCRIPTION
Reverts MicrosoftDocs/azure-docs-sdk-dotnet#2565

Testing shows this package works in isolation. It should be possible to run it in the docs build successfully. Not sure why it was failing previously. 